### PR TITLE
Update configure test for libv8 with c++11

### DIFF
--- a/configure
+++ b/configure
@@ -41,7 +41,7 @@ echo "Using PKG_CFLAGS=$PKG_CFLAGS"
 echo "Using PKG_LIBS=$PKG_LIBS"
 
 # Test for libv8
-echo "#include $PKG_TEST_HEADER" | ${CXXCPP} ${CPPFLAGS} ${PKG_CFLAGS} ${CXXFLAGS} -xc++ - >/dev/null 2>&1
+echo "#include $PKG_TEST_HEADER" | ${CXXCPP} ${CPPFLAGS} ${PKG_CFLAGS} ${CXXFLAGS} -xc++ -std=c++11 - >/dev/null 2>&1
 if [ $? -ne 0 ]; then
   echo "------------------------- ANTICONF ERROR ---------------------------"
   echo "Configuration failed because $PKG_CONFIG_NAME was not found. Try installing:"


### PR DESCRIPTION
Addition of c++11 in the configure script while checking for libv8. This is important when c++11 is not supported by default, such as the gcc4x compilers on CentOS, because the check will otherwise fail even though libv8 and the appropriate headers are present. I have successfully tested it line with gcc 4.8.5 and 6.3.0 on CentOS 7 against V8 7.3.492.22 as well as 3.14.5.10 and all seemed to work fine. 