### PR TITLE
[WIP] further updates of v8

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -39,7 +39,7 @@ void start_v8_isolate(void *dll){
     v8::V8::InitializeICUDefaultLocation(V8_ICU_DATA_PATH);
   }
 #endif
-  std::unique_ptr<v8::Platform> platform = v8::platform::NewDefaultPlatform();
+  static std::unique_ptr<v8::Platform> platform = v8::platform::NewDefaultPlatform();
   v8::V8::InitializePlatform(platform.get());
   v8::V8::Initialize();
   v8::Isolate::CreateParams create_params;

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -217,7 +217,7 @@ v8::Local<v8::Object> console_template(){
   console_r->Set(ToJSString("get"), v8::FunctionTemplate::New(isolate, console_r_get));
   console_r->Set(ToJSString("eval"), v8::FunctionTemplate::New(isolate, console_r_eval));
   console_r->Set(ToJSString("assign"), v8::FunctionTemplate::New(isolate, console_r_assign));
-  return console->NewInstance();
+  return console->NewInstance(isolate->GetCurrentContext()).ToLocalChecked();
 }
 
 // [[Rcpp::export]]

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -39,8 +39,12 @@ void start_v8_isolate(void *dll){
     v8::V8::InitializeICUDefaultLocation(V8_ICU_DATA_PATH);
   }
 #endif
+#if (V8_MAJOR_VERSION * 100 + V8_MINOR_VERSION) >= 704
   static std::unique_ptr<v8::Platform> platform = v8::platform::NewDefaultPlatform();
   v8::V8::InitializePlatform(platform.get());
+#else
+  v8::V8::InitializePlatform(v8::platform::CreateDefaultPlatform());
+#endif
   v8::V8::Initialize();
   v8::Isolate::CreateParams create_params;
   create_params.array_buffer_allocator =

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -39,7 +39,8 @@ void start_v8_isolate(void *dll){
     v8::V8::InitializeICUDefaultLocation(V8_ICU_DATA_PATH);
   }
 #endif
-  v8::V8::InitializePlatform(v8::platform::CreateDefaultPlatform());
+  std::unique_ptr<v8::Platform> platform = v8::platform::NewDefaultPlatform();
+  v8::V8::InitializePlatform(platform.get());
   v8::V8::Initialize();
   v8::Isolate::CreateParams create_params;
   create_params.array_buffer_allocator =


### PR DESCRIPTION
Compiling V8 on a new computer I came across build errors since Arch Linux already updated icu to release 64, which is not yet  covered by "stable" v8 tests. Nothing dramatically changed, still a fraction of the checks fail.

So I build current v8 master which provides fixes for those tests. Master builds fine (one test still fails, for which I blame icu), but brings some new outdated v8-API along. This PR should correct these. The R-package builds, but `V8::v8()` crashes with unmapped memory. Will require some more thinking ...

Will have to come up with a decision how to handle backward comparability with v8-6.x