### PR TITLE
add class argument to expect_error

### DIFF
--- a/tests/testthat/test_callback.R
+++ b/tests/testthat/test_callback.R
@@ -27,10 +27,10 @@ test_that("console.r.call", {
   expect_equal(length(ctx$get("console.r.call('rnorm', {n: 2,mean:10, sd:5})")), 2)
   expect_equal(length(ctx$get("console.r.call('rnorm', 3)")), 3)
   expect_equal(ctx$get("console.r.call('function(x){x^2}', {x:12})"), 144)
-  expect_error(ctx$get("console.r.call('rnorm')"), "missing")
+  expect_error(ctx$get("console.r.call('rnorm')"), "missing", class = "std::runtime_error")
 })
 
 test_that("console.r.eval", {
   expect_is(ctx$eval("console.r.eval('invisible(sessionInfo())')"), "character")
-  expect_error(ctx$eval("console.r.eval('doesnotexists')"), "not found")
+  expect_error(ctx$eval("console.r.eval('doesnotexists')"), "not found", class = "std::runtime_error")
 })

--- a/tests/testthat/test_exception.R
+++ b/tests/testthat/test_exception.R
@@ -4,5 +4,5 @@ context("Error message")
 # The test is automatically removed by the autobrew script
 test_that("SyntaxError from V8", {
   ctx <- V8::v8()
-  expect_error(ctx$eval('var foo = }bla}'), 'SyntaxError')
+  expect_error(ctx$eval('var foo = }bla}'), 'SyntaxError', class = "std::invalid_argument")
 })


### PR DESCRIPTION
Similar to #67 this silences warnings thrown by `testthat`. This adds a `class` argument to `expect_error()` as told by the thrown warning message. Might require a dependency to `testthat > someversion`?