### PR TITLE
Fix check for pointer compression.

### DIFF
--- a/configure
+++ b/configure
@@ -69,7 +69,12 @@ fi
 
 # Test if we need to enable pointer compression (Usually 8.4 and up)
 echo "Running feature test for pointer compression..."
-${CXX} ${CPPFLAGS} ${PKG_CFLAGS} -DV8_ENABLE_CHECKS tools/test.cpp -o pctest ${LDFLAGS} ${PKG_LIBS}
+${CXX} ${CPPFLAGS} ${PKG_CFLAGS} ${CXXFLAGS} -DV8_ENABLE_CHECKS tools/test.cpp -o pctest ${LDFLAGS} ${PKG_LIBS}
+if [ $? -ne 0 ]; then
+  echo "Unable to check for pointer compression!"
+  exit 1
+fi
+
 { ./pctest; } 2>> configure.log
 if [ $? -eq 0 ]; then
   echo "Pointer compression not needed"


### PR DESCRIPTION
The `CXXFLAGS` were not passed to the compile of the test executable, which causes issues if some flags in `LDFLAGS` depend on flags also being in `CXXFLAGS`.

Also, the exit status of the compilation is not checked, so this could continue to guess a result even if there's no test executable.