### PR TITLE
Support DOWNLOAD_STATIC_LIBV8 on CentOS 7

### DIFF
--- a/configure
+++ b/configure
@@ -56,7 +56,7 @@ elif [ "$DOWNLOAD_STATIC_LIBV8" ]; then
   else
     URL="http://jeroen.github.io/V8/v8-6.8.275.32-linux.tar.gz"
   fi
-  ${R_HOME}/bin/R -e "download.file('$URL' 'libv8.tar.gz')"
+  ${R_HOME}/bin/R -e "download.file('$URL','libv8.tar.gz')"
   tar xzf libv8.tar.gz
   PKG_CFLAGS="-I${PWD}/v8/include"
   PKG_LIBS="-L${PWD}/v8/lib -lv8_monolith"

--- a/configure
+++ b/configure
@@ -50,8 +50,13 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   PKG_CFLAGS="-I${V8HOME}/include -I${V8HOME}/libexec/include"
   PKG_LIBS="-L${V8HOME}/libexec $PKG_LIBS"
 elif [ "$DOWNLOAD_STATIC_LIBV8" ]; then
-  # This requires x86_64 and at least GCC-5, i.e. anything except for centos-7
-  ${R_HOME}/bin/R -e 'download.file("http://jeroen.github.io/V8/v8-8.3.110.13-linux.tar.gz", "libv8.tar.gz")'
+  IS_GCC4=$($CXX --version | grep -P '^g++.*[^\d.]4(\.\d){2}')
+  if [ $? -ne 0 ] || [ -z "$IS_GCC4" ]; then
+    URL="http://jeroen.github.io/V8/v8-8.3.110.13-linux.tar.gz"
+  else
+    URL="http://jeroen.github.io/V8/v8-6.8.275.32-linux.tar.gz"
+  fi
+  ${R_HOME}/bin/R -e "download.file('$URL' 'libv8.tar.gz')"
   tar xzf libv8.tar.gz
   PKG_CFLAGS="-I${PWD}/v8/include"
   PKG_LIBS="-L${PWD}/v8/lib -lv8_monolith"

--- a/configure
+++ b/configure
@@ -54,7 +54,7 @@ elif [ "$DOWNLOAD_STATIC_LIBV8" ]; then
   if [ $? -ne 0 ] || [ -z "$IS_GCC4" ]; then
     URL="http://jeroen.github.io/V8/v8-8.3.110.13-linux.tar.gz"
   else
-    URL="http://jeroen.github.io/V8/v8-6.8.275.32-gcc49.tar.gz"
+    URL="http://jeroen.github.io/V8/v8-6.8.275.32-gcc48.tar.gz"
   fi
   ${R_HOME}/bin/R -e "download.file('$URL','libv8.tar.gz')"
   tar xzf libv8.tar.gz

--- a/configure
+++ b/configure
@@ -54,7 +54,7 @@ elif [ "$DOWNLOAD_STATIC_LIBV8" ]; then
   if [ $? -ne 0 ] || [ -z "$IS_GCC4" ]; then
     URL="http://jeroen.github.io/V8/v8-8.3.110.13-linux.tar.gz"
   else
-    URL="http://jeroen.github.io/V8/v8-6.8.275.32-linux.tar.gz"
+    URL="http://jeroen.github.io/V8/v8-6.8.275.32-gcc49.tar.gz"
   fi
   ${R_HOME}/bin/R -e "download.file('$URL','libv8.tar.gz')"
   tar xzf libv8.tar.gz


### PR DESCRIPTION
Support CentOS 7, perhaps others.

This works with centos-7 and g++-4.9 from xenial. 

It did not work with some older 4.8 branches such as trusty. I think this toolchain is buggy because we get the same error when trying to build libv8 in trusty. But this distro is probably not important anymore.