### PR TITLE
Switch v8::Handle<> to v8::Local<>

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -202,7 +202,7 @@ Rcpp::RObject context_eval(Rcpp::String src, Rcpp::XPtr< v8::Persistent<v8::Cont
 
   // Compile source code
   v8::TryCatch trycatch(isolate);
-  v8::Handle<v8::Script> script = compile_source(src, ctx.checked_get()->Get(isolate));
+  v8::Local<v8::Script> script = compile_source(src, ctx.checked_get()->Get(isolate));
   if(script.IsEmpty()) {
     v8::String::Utf8Value exception(isolate, trycatch.Exception());
     throw std::invalid_argument(ToCString(exception));
@@ -210,7 +210,7 @@ Rcpp::RObject context_eval(Rcpp::String src, Rcpp::XPtr< v8::Persistent<v8::Cont
 
   // Run the script to get the result.
   v8::MaybeLocal<v8::Value> res = script->Run(ctx.checked_get()->Get(isolate));
-  v8::Handle<v8::Value> result = safe_to_local(res);
+  v8::Local<v8::Value> result = safe_to_local(res);
   if(result.IsEmpty()){
     v8::String::Utf8Value exception(isolate, trycatch.Exception());
     throw std::runtime_error(ToCString(exception));
@@ -243,8 +243,8 @@ bool write_array_buffer(Rcpp::String key, Rcpp::RawVector data, Rcpp::XPtr< v8::
   v8::TryCatch trycatch(isolate);
 
   // Initiate ArrayBuffer and ArrayBufferView (uint8 typed array)
-  v8::Handle<v8::ArrayBuffer> buffer = v8::ArrayBuffer::New(isolate, data.size());
-  v8::Handle<v8::Uint8Array> typed_array = v8::Uint8Array::New(buffer, 0, data.size());
+  v8::Local<v8::ArrayBuffer> buffer = v8::ArrayBuffer::New(isolate, data.size());
+  v8::Local<v8::Uint8Array> typed_array = v8::Uint8Array::New(buffer, 0, data.size());
 #if (V8_MAJOR_VERSION * 100 + V8_MINOR_VERSION) >= 901
   memcpy(buffer->GetBackingStore()->Data(), data.begin(), data.size());
 #else
@@ -276,7 +276,7 @@ bool context_validate(Rcpp::String src, Rcpp::XPtr< v8::Persistent<v8::Context> 
 
   // Try to compile, catch errors
   v8::TryCatch trycatch(isolate);
-  v8::Handle<v8::Script> script = compile_source(src, ctx.checked_get()->Get(isolate));
+  v8::Local<v8::Script> script = compile_source(src, ctx.checked_get()->Get(isolate));
   return !script.IsEmpty();
 }
 


### PR DESCRIPTION
`v8::Handle` is identical to `v8::Local` if `V8_IMMINENT_DEPRECATION_WARNINGS` is undefined. [1] This is currently stopping us from building with `-DV8_DEPRECATION_WARNINGS` and `-DV8_IMMINENT_DEPRECATION_WARNINGS`. Building with these defines provides the following output that would have spotted the change that was solved in #117.
This PR is nothing urgent and merely an idea to be able to build with these flags (the `v8::Handle` imminent deprecation was added ~6 years ago, looks like there is no rush).

```
bindings.cpp: In function ‘Rcpp::RObject convert_object(v8::Local<v8::Value>)’:
bindings.cpp:177:46: warning: ‘v8::ArrayBuffer::Contents v8::ArrayBuffer::GetContents()’ is deprecated: Use GetBackingStore. See http://crbug.com/v8/9908. [-Wdeprecated-declarations]
  177 |     memcpy(data.begin(), buffer->GetContents().Data(), data.size());
      |                                              ^
In file included from V8_types.h:1,
                 from bindings.cpp:2:
/usr/include/v8.h:5584:12: note: declared here
 5584 |   Contents GetContents();
      |            ^~~~~~~~~~~
bindings.cpp: In function ‘bool write_array_buffer(Rcpp::String, Rcpp::RawVector, Rcpp::XPtr<v8::Persistent<v8::Context> >)’:
bindings.cpp:251:30: warning: ‘v8::ArrayBuffer::Contents v8::ArrayBuffer::GetContents()’ is deprecated: Use GetBackingStore. See http://crbug.com/v8/9908. [-Wdeprecated-declarations]
  251 |   memcpy(buffer->GetContents().Data(), data.begin(), data.size());
      |                              ^
In file included from V8_types.h:1,
                 from bindings.cpp:2:
/usr/include/v8.h:5584:12: note: declared here
 5584 |   Contents GetContents();
      |            ^~~~~~~~~~~
```

[1] https://github.com/v8/v8/blob/c9d83e5c1faa592c1cf9c55fcad03f8e47124cb5/include/v8.h#L353-L357