### PR TITLE
V8 10.8 brings V8_ENABLE_SANDBOX

### DIFF
--- a/configure
+++ b/configure
@@ -133,6 +133,17 @@ else
 fi
 rm -Rf pctest*
 
+echo "Running feature test for sandbox..."
+${CXX} ${CPPFLAGS} ${PKG_CFLAGS} ${CXXFLAGS} -DV8_ENABLE_SANDBOX tools/test.cpp -o pctest ${LDFLAGS} ${PKG_LIBS} -ldl -pthread  2>> configure.log
+{ ./pctest; } 2>> configure.log
+if [ $? -eq 0 ]; then
+  echo "Enabling sandbox"
+  PKG_CFLAGS="$PKG_CFLAGS -DV8_ENABLE_SANDBOX"
+else
+  echo "Sandbox not needed"
+fi
+rm -Rf pctest*
+
 # Assume a modern V8 API
 sed -e "s|@cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" -e "s|CXX11|${CXX_STD}|" src/Makevars.in > src/Makevars
 exit 0


### PR DESCRIPTION
In [this commit](https://chromium.googlesource.com/v8/v8.git/+/5b9401dde4532719220ac698eef7012cdd371903) upstream V8 switched to enable `v8_enable_sandbox` per default.

Unfortunately, without any changes on our side, this leads to the following error:

`Embedder-vs-V8 build configuration mismatch. On embedder side sandbox is DISABLED while on V8 side it's ENABLED.`

This can be solved with `-DV8_ENABLE_SANDBOX` (and the snippet that enables the sandbox; adapted from V8's hello-world.cc file). ~~I tried to reuse the pointer compression check to see if we need to enable the sandbox, but this check is broken. It only works if v8 has sandbox support. I have no idea how to check this at the moment.~~
I reused the pointer compression test in a waterfall. Once the pointer compression check is passed, we try to build and run with `-DV8_ENABLE_SANDBOX`. If this succeeds, the flag is passed down. (For this to work, I had to pull in platform creation into the `#ifdef`.)

Right now I'm building my v8 Arch package with v8 sandbox disabled. Presumably no one else is affected until 10.5 is released (we're ~~currently~~ still early in the release cycle) and Google could still change things on their end.