### PR TITLE
Fix test.cpp: v8 in node 18 needs platform init

### DIFF
--- a/tools/test.cpp
+++ b/tools/test.cpp
@@ -3,5 +3,7 @@
 using namespace v8;
 
 int main(){
+  std::unique_ptr<Platform> platform = platform::NewDefaultPlatform();
+  V8::InitializePlatform(platform.get());
   V8::Initialize();
 }


### PR DESCRIPTION
I checked that this still works with v8 in node 16