### PR TITLE
Provide NODE_JS_16 and NODE_JS_18

### DIFF
--- a/configure
+++ b/configure
@@ -133,6 +133,20 @@ else
 fi
 rm -Rf pctest*
 
+# Provide macros to avoid calling 'buffer->GetBackingStore()->Data()' due to
+# a UBSAN warning: https://github.com/jeroen/V8/issues/152
+if [ "$IS_MACOS" ] || [ "$IS_UBUNTU" ] || [ "$IS_RHEL" ] || [ "$CI" ]; then
+node_version="/usr/include/node/node_version.h"
+major=$(grep -m 1 NODE_MAJOR_VERSION $node_version | sed 's/^.* //g')
+minor=$(grep -m 1 NODE_MINOR_VERSION $node_version | sed 's/^.* //g')
+echo "found nodejs $major.$minor"
+if [ ${major} -le 16 ]; then
+  PKG_CFLAGS="$PKG_CFLAGS -DNODE_JS_16"
+elif [ ${major} -eq 18 ] && [ ${minor} -ge 8 ]; then
+  PKG_CFLAGS="$PKG_CFLAGS -DNODE_JS_18"
+fi
+fi
+
 # Assume a modern V8 API
 sed -e "s|@cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" -e "s|CXX11|${CXX_STD}|" src/Makevars.in > src/Makevars
 exit 0

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -208,12 +208,12 @@ static Rcpp::RObject convert_object(v8::Local<v8::Value> value){
     v8::Local<v8::ArrayBuffer> buffer = value->IsArrayBufferView() ?
     value.As<v8::ArrayBufferView>()->Buffer() : value.As<v8::ArrayBuffer>();
     Rcpp::RawVector data(buffer->ByteLength());
-#if (V8_MAJOR_VERSION * 100 + V8_MINOR_VERSION) >= 1005
+#if NODE_JS_18 || (V8_MAJOR_VERSION * 100 + V8_MINOR_VERSION) >= 1005
     memcpy(data.begin(), buffer->Data(), data.size());
+#elif NODE_JS_16 || (V8_MAJOR_VERSION * 100 + V8_MINOR_VERSION) < 901
+    memcpy(data.begin(), buffer->GetContents().Data(), data.size());
 #elif (V8_MAJOR_VERSION * 100 + V8_MINOR_VERSION) >= 901
     memcpy(data.begin(), buffer->GetBackingStore()->Data(), data.size());
-#else
-    memcpy(data.begin(), buffer->GetContents().Data(), data.size());
 #endif
     return data;
   } else {
@@ -314,12 +314,12 @@ bool write_array_buffer(Rcpp::String key, Rcpp::RawVector data, ctxptr ctx){
   v8::Local<v8::ArrayBuffer> buffer = v8::ArrayBuffer::New(isolate, data.size());
   v8::Local<v8::Uint8Array> typed_array = v8::Uint8Array::New(buffer, 0, data.size());
 
-#if (V8_MAJOR_VERSION * 100 + V8_MINOR_VERSION) >= 1005
+#if NODE_JS_18 || (V8_MAJOR_VERSION * 100 + V8_MINOR_VERSION) >= 1005
   memcpy(buffer->Data(), data.begin(), data.size());
+#elif NODE_JS_16 || (V8_MAJOR_VERSION * 100 + V8_MINOR_VERSION) < 901
+  memcpy(buffer->GetContents().Data(), data.begin(), data.size());
 #elif (V8_MAJOR_VERSION * 100 + V8_MINOR_VERSION) >= 901
   memcpy(buffer->GetBackingStore()->Data(), data.begin(), data.size());
-#else
-  memcpy(buffer->GetContents().Data(), data.begin(), data.size());
 #endif
 
   // Assign to object (delete first if exists)


### PR DESCRIPTION
Maybe something along the lines of this:

* Might be to much bash for CRAN, but it works in RDsan with `libnode-dev`
* Hard coded to search for a specific path. In Fedora Rawhide and Ubuntu 22 this is `/usr/include/node` was it `/usr/include` previously?
