### PR TITLE
fix array bounds warning

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -124,7 +124,9 @@ static void pump_promises(){
 /* Try to resolve pending promises */
 static void ConsolePump(const v8::FunctionCallbackInfo<v8::Value>& args) {
   pump_promises();
-  args.GetReturnValue().Set(v8::Undefined(args.GetIsolate()));
+  if(!v8::Undefined(args.GetIsolate()).IsEmpty()){
+    args.GetReturnValue().Set(v8::Undefined(args.GetIsolate()));
+  }
 }
 
 
@@ -136,7 +138,9 @@ static void ConsoleLog(const v8::FunctionCallbackInfo<v8::Value>& args) {
     Rprintf("%s", ToCString(str));
   }
   Rprintf("\n");
-  args.GetReturnValue().Set(v8::Undefined(args.GetIsolate()));
+  if(!v8::Undefined(args.GetIsolate()).IsEmpty()){
+    args.GetReturnValue().Set(v8::Undefined(args.GetIsolate()));
+  }
 }
 
 /* console.warn */
@@ -146,7 +150,9 @@ static void ConsoleWarn(const v8::FunctionCallbackInfo<v8::Value>& args) {
     v8::String::Utf8Value str(args.GetIsolate(), args[i]);
     Rf_warningcall_immediate(R_NilValue, ToCString(str));
   }
-  args.GetReturnValue().Set(v8::Undefined(args.GetIsolate()));
+  if(!v8::Undefined(args.GetIsolate()).IsEmpty()){
+    args.GetReturnValue().Set(v8::Undefined(args.GetIsolate()));
+  }
 }
 
 /* console.error */
@@ -154,7 +160,9 @@ static void ConsoleError(const v8::FunctionCallbackInfo<v8::Value>& args) {
   if(args.Length()){
     args.GetIsolate()->ThrowException(args[0]);
   }
-  args.GetReturnValue().Set(v8::Undefined(args.GetIsolate()));
+  if(!v8::Undefined(args.GetIsolate()).IsEmpty()){
+    args.GetReturnValue().Set(v8::Undefined(args.GetIsolate()));
+  }
 }
 
 void r_callback(std::string cb, const v8::FunctionCallbackInfo<v8::Value>& args) {


### PR DESCRIPTION
This fixes the following warnings I'm seeing with v8 11.4.71 and gcc (GCC) 12.2.1 20230201. I have switched the sandbox on in v8, not sure if this causes the warning or if something else triggered it (gcc update or something else in v8).

I build with `-DV8_DEPRECATED -DV8_DEPRECATE_SOON`, but that should not matter.

```txt
==> R CMD INSTALL --preclean --no-multiarch --with-keep.source V8

* installing to library ‘/home/jmg/R/x86_64-pc-linux-gnu-library/4.2’
* installing *source* package ‘V8’ ...
** using staged installation
Found C++17 compiler: g++
Using CXXCPP=g++ -std=gnu++17 -E
Using PKG_CFLAGS=-I/usr/include/v8 -I/usr/include/v8-3.14
Using PKG_LIBS=-lv8 -lv8_libplatform
Running feature test for pointer compression...
Enabling pointer compression
Running feature test for sandbox...
Enabling sandbox
rm -f V8.so RcppExports.o bindings.o
g++ -std=gnu++17 -I"/usr/include/R/" -DNDEBUG -I/usr/include/v8 -I/usr/include/v8-3.14 -DV8_COMPRESS_POINTERS -DV8_ENABLE_SANDBOX  -DV8_DEPRECATED -DV8_DEPRECATE_SOON -I'/home/jmg/R/x86_64-pc-linux-gnu-library/4.2/Rcpp/include' -I/usr/local/include  -fvisibility=hidden -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -Wp,-D_GLIBCXX_ASSERTIONS -flto=auto -ffat-lto-objects  -Wall -c RcppExports.cpp -o RcppExports.o
** libs
g++ -std=gnu++17 -I"/usr/include/R/" -DNDEBUG -I/usr/include/v8 -I/usr/include/v8-3.14 -DV8_COMPRESS_POINTERS -DV8_ENABLE_SANDBOX  -DV8_DEPRECATED -DV8_DEPRECATE_SOON -I'/home/jmg/R/x86_64-pc-linux-gnu-library/4.2/Rcpp/include' -I/usr/local/include  -fvisibility=hidden -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -Wp,-D_GLIBCXX_ASSERTIONS -flto=auto -ffat-lto-objects  -Wall -c bindings.cpp -o bindings.o
In file included from /usr/include/v8-handle-base.h:8,
                 from /usr/include/v8-local-handle.h:12,
                 from /usr/include/v8-array-buffer.h:12,
                 from /usr/include/v8.h:24,
                 from V8_types.h:1,
                 from bindings.cpp:2:
In function ‘v8::internal::Internals::GetRoot(v8::Isolate*, int)’,
    inlined from ‘v8::ReturnValue<v8::Value>::GetDefaultValue()’ at /usr/include/v8-function-callback.h:404:20,
    inlined from ‘v8::ReturnValue<v8::Value>::Set<v8::Primitive>(v8::Local<v8::Primitive>)void’ at /usr/include/v8-function-callback.h:308:30,
    inlined from ‘ConsoleError(v8::FunctionCallbackInfo<v8::Value> const&)’ at bindings.cpp:157:28:
/usr/include/v8-internal.h:766:39: warning: array subscript 0 is outside array bounds of ‘Address[0:]’ [-Warray-bounds]
  766 |     return *GetRootSlot(isolate, index);
      |                                       ^
In function ‘v8::internal::Internals::GetRoot(v8::Isolate*, int)’,
    inlined from ‘v8::ReturnValue<v8::Value>::GetDefaultValue()’ at /usr/include/v8-function-callback.h:404:20,
    inlined from ‘v8::ReturnValue<v8::Value>::Set<v8::Primitive>(v8::Local<v8::Primitive>)void’ at /usr/include/v8-function-callback.h:308:30,
    inlined from ‘ConsoleWarn(v8::FunctionCallbackInfo<v8::Value> const&)’ at bindings.cpp:149:28:
/usr/include/v8-internal.h:766:39: warning: array subscript 0 is outside array bounds of ‘Address[0:]’ [-Warray-bounds]
  766 |     return *GetRootSlot(isolate, index);
      |                                       ^
In function ‘v8::internal::Internals::GetRoot(v8::Isolate*, int)’,
    inlined from ‘v8::ReturnValue<v8::Value>::GetDefaultValue()’ at /usr/include/v8-function-callback.h:404:20,
    inlined from ‘v8::ReturnValue<v8::Value>::Set<v8::Primitive>(v8::Local<v8::Primitive>)void’ at /usr/include/v8-function-callback.h:308:30,
    inlined from ‘ConsoleLog(v8::FunctionCallbackInfo<v8::Value> const&)’ at bindings.cpp:139:28:
/usr/include/v8-internal.h:766:39: warning: array subscript 0 is outside array bounds of ‘Address[0:]’ [-Warray-bounds]
  766 |     return *GetRootSlot(isolate, index);
      |                                       ^
In function ‘v8::internal::Internals::GetRoot(v8::Isolate*, int)’,
    inlined from ‘v8::ReturnValue<v8::Value>::GetDefaultValue()’ at /usr/include/v8-function-callback.h:404:20,
    inlined from ‘v8::ReturnValue<v8::Value>::Set<v8::Primitive>(v8::Local<v8::Primitive>)void’ at /usr/include/v8-function-callback.h:308:30,
    inlined from ‘ConsolePump(v8::FunctionCallbackInfo<v8::Value> const&)’ at bindings.cpp:127:28:
/usr/include/v8-internal.h:766:39: warning: array subscript 0 is outside array bounds of ‘Address[0:]’ [-Warray-bounds]
  766 |     return *GetRootSlot(isolate, index);
      |                                       ^
g++ -std=gnu++17 -shared -L/usr/lib64/R/lib -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -flto=auto -o V8.so RcppExports.o bindings.o -lv8 -lv8_libplatform -L/usr/lib64/R/lib -lR
installing to /home/jmg/R/x86_64-pc-linux-gnu-library/4.2/00LOCK-V8/00new/V8/libs
** R
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
** checking absolute paths in shared objects and dynamic libraries
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (V8)
``` 

With this PR:
```txt
==> R CMD INSTALL --preclean --no-multiarch --with-keep.source V8

* installing to library ‘/home/jmg/R/x86_64-pc-linux-gnu-library/4.2’
* installing *source* package ‘V8’ ...
** using staged installation
Found C++17 compiler: g++
Using CXXCPP=g++ -std=gnu++17 -E
Using PKG_CFLAGS=-I/usr/include/v8 -I/usr/include/v8-3.14
Using PKG_LIBS=-lv8 -lv8_libplatform
Running feature test for pointer compression...
Enabling pointer compression
Running feature test for sandbox...
Enabling sandbox
rm -f V8.so RcppExports.o bindings.o
g++ -std=gnu++17 -I"/usr/include/R/" -DNDEBUG -I/usr/include/v8 -I/usr/include/v8-3.14 -DV8_COMPRESS_POINTERS -DV8_ENABLE_SANDBOX  -DV8_DEPRECATED -DV8_DEPRECATE_SOON -I'/home/jmg/R/x86_64-pc-linux-gnu-library/4.2/Rcpp/include' -I/usr/local/include  -fvisibility=hidden -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -Wp,-D_GLIBCXX_ASSERTIONS -flto=auto -ffat-lto-objects  -Wall -c RcppExports.cpp -o RcppExports.o
** libs
g++ -std=gnu++17 -I"/usr/include/R/" -DNDEBUG -I/usr/include/v8 -I/usr/include/v8-3.14 -DV8_COMPRESS_POINTERS -DV8_ENABLE_SANDBOX  -DV8_DEPRECATED -DV8_DEPRECATE_SOON -I'/home/jmg/R/x86_64-pc-linux-gnu-library/4.2/Rcpp/include' -I/usr/local/include  -fvisibility=hidden -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -Wp,-D_GLIBCXX_ASSERTIONS -flto=auto -ffat-lto-objects  -Wall -c bindings.cpp -o bindings.o
g++ -std=gnu++17 -shared -L/usr/lib64/R/lib -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -flto=auto -o V8.so RcppExports.o bindings.o -lv8 -lv8_libplatform -L/usr/lib64/R/lib -lR
installing to /home/jmg/R/x86_64-pc-linux-gnu-library/4.2/00LOCK-V8/00new/V8/libs
** R
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
** checking absolute paths in shared objects and dynamic libraries
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (V8)
```