### PR TITLE
minor update to v8_intro.Rmd

### DIFF
--- a/vignettes/v8_intro.Rmd
+++ b/vignettes/v8_intro.Rmd
@@ -173,17 +173,10 @@ ct$eval('var cf = crossfilter || console.error("failed to load crossfilter!")')
 
 ## The Global Namespace
 
-Unlike what you might be used to from Node or your browser, the global namespace for a new context if very minimal. By default it contains only a few objects: `global` (a reference to itself), `console` (for `console.log` and friends) and `print` (an alias of console.log needed by some JavaScript libraries)
+Unlike what you might be used to from Node or your browser, the global namespace for a new context is very minimal. By default it contains only a few objects: `global` (a reference to itself), `console` (for `console.log` and friends) and `print` (an alias of console.log needed by some JavaScript libraries)
 
 ```{r}
-ct <- v8(typed_arrays = FALSE);
-ct$get(JS("Object.keys(global)"))
-```
-
-If typed arrays are enabled it contains some additional functions:
-
-```{r}
-ct <- v8(typed_arrays = TRUE);
+ct <- v8();
 ct$get(JS("Object.keys(global)"))
 ```
 


### PR DESCRIPTION
fix typo + remove example with `typed_arrays = FALSE` (since there is no difference in output) in 'The Global Namespace' section