### PR TITLE
bindings: include fstream

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -1,5 +1,6 @@
 #include <libplatform/libplatform.h>
 #include "V8_types.h"
+#include <fstream>
 
 /* use conditional apis below */
 #define V8_VERSION_TOTAL (V8_MAJOR_VERSION * 100 + V8_MINOR_VERSION)


### PR DESCRIPTION
Not sure ~~if something~~ what changed on the V8 side of things, but building with V8 13.6.129 I'm seeing: 

```R
==> Rcpp::compileAttributes()

* Updated R/RcppExports.R

==> R CMD INSTALL --preclean --no-multiarch --with-keep.source V8

* installing to library ‘/home/jmg/R/x86_64-pc-linux-gnu-library/4.4/_build’
* installing *source* package ‘V8’ ...
** using staged installation
Found C++20 compiler: g++
Using CXXCPP=g++ -std=gnu++20 -E
Using PKG_CFLAGS=-I/usr/include/v8
Using PKG_LIBS=-lv8 -lv8_libplatform
Running feature test for pointer compression...
Enabling pointer compression
Running feature test for sandbox...
Enabling sandbox
** libs
rm -f V8.so RcppExports.o bindings.o
g++ -std=gnu++20 -I"/usr/include/R/" -DNDEBUG -I/usr/include/v8 -DV8_COMPRESS_POINTERS -DV8_ENABLE_SANDBOX -I'/home/jmg/R/x86_64-pc-linux-gnu-library/4.4/Rcpp/include' -I/usr/local/include   -fvisibility=hidden -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection         -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Wp,-D_GLIBCXX_ASSERTIONS -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects   -c RcppExports.cpp -o RcppExports.o
using C++ compiler: ‘g++ (GCC) 14.2.1 20250207’
using C++20
g++ -std=gnu++20 -I"/usr/include/R/" -DNDEBUG -I/usr/include/v8 -DV8_COMPRESS_POINTERS -DV8_ENABLE_SANDBOX -I'/home/jmg/R/x86_64-pc-linux-gnu-library/4.4/Rcpp/include' -I/usr/local/include   -fvisibility=hidden -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection         -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Wp,-D_GLIBCXX_ASSERTIONS -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects   -c bindings.cpp -o bindings.o
bindings.cpp: In function ‘std::string read_text(std::string)’:
bindings.cpp:59:27: error: variable ‘std::ifstream t’ has initializer but incomplete type
   59 |   std::ifstream t(filename);
      |                           ^
bindings.cpp:3:1: note: ‘std::ifstream’ is defined in header ‘<fstream>’; this is probably fixable by adding ‘#include <fstream>’
    2 | #include "V8_types.h"
  +++ |+#include <fstream>
    3 | 
make: *** [/usr/lib64/R/etc/Makeconf:204: bindings.o] Error 1
ERROR: compilation failed for package ‘V8’
* removing ‘/home/jmg/R/x86_64-pc-linux-gnu-library/4.4/_build/V8’

Exited with status 1.
```