### PR TITLE
add scope to start_v8_isolate()

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -206,10 +206,8 @@ void start_v8_isolate(void *dll){
   if(!isolate)
     throw std::runtime_error("Failed to initiate V8 isolate");
 
-#if V8_VERSION_TOTAL >= 1400
   v8::Isolate::Scope isolate_scope(isolate);
   v8::HandleScope handle_scope(isolate);
-#endif
 
   isolate->AddMessageListener(message_cb);
   isolate->SetFatalErrorHandler(fatal_cb);

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -205,6 +205,12 @@ void start_v8_isolate(void *dll){
   isolate = v8::Isolate::New(create_params);
   if(!isolate)
     throw std::runtime_error("Failed to initiate V8 isolate");
+
+#if V8_VERSION_TOTAL >= 1400
+  v8::Isolate::Scope isolate_scope(isolate);
+  v8::HandleScope handle_scope(isolate);
+#endif
+
   isolate->AddMessageListener(message_cb);
   isolate->SetFatalErrorHandler(fatal_cb);
 


### PR DESCRIPTION
This fixes the following startup crash. I cannot ping point this to a specific commit. It happened somewhere between 14.0.181 and 14.0.255. Probably related to even stricter sandboxing. The change should be harmless and could probably be enabled for earlier releases of V8.

```R
> R CMD build V8
* checking for file ‘V8/DESCRIPTION’ ... OK
* preparing ‘V8’:
* checking DESCRIPTION meta-information ... OK
* cleaning src
* running ‘cleanup’
* installing the package to process help pages
      -----------------------------------
* installing *source* package ‘V8’ ...
** this is package ‘V8’ version ‘6.0.4’
** using staged installation
Found C++20 compiler: g++
Using CXXCPP=g++ -std=gnu++20 -E
Using PKG_CFLAGS=-I/usr/include/v8
Using PKG_LIBS=-lv8 -lv8_libplatform
Running feature test for pointer compression...
Enabling pointer compression
Running feature test for sandbox...
Enabling sandbox
** libs
using C++ compiler: ‘g++ (GCC) 15.1.1 20250425’
using C++20
g++ -std=gnu++20 -I"/usr/include/R/" -DNDEBUG -I/usr/include/v8 -DV8_COMPRESS_POINTERS -DV8_ENABLE_SANDBOX -DV8_DEPRECATED -DV8_DEPRECATE_SOON -I'/home/jmg/R/x86_64-pc-linux-gnu-library/4.5/Rcpp/include' -I/usr/local/include   -fvisibility=hidden -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection         -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Wp,-D_GLIBCXX_ASSERTIONS -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects   -c RcppExports.cpp -o RcppExports.o
g++ -std=gnu++20 -I"/usr/include/R/" -DNDEBUG -I/usr/include/v8 -DV8_COMPRESS_POINTERS -DV8_ENABLE_SANDBOX -DV8_DEPRECATED -DV8_DEPRECATE_SOON -I'/home/jmg/R/x86_64-pc-linux-gnu-library/4.5/Rcpp/include' -I/usr/local/include   -fvisibility=hidden -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection         -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Wp,-D_GLIBCXX_ASSERTIONS -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects   -c bindings.cpp -o bindings.o
g++ -std=gnu++20 -shared -L/usr/lib64/R/lib -Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,pack-relative-relocs -flto=auto -o V8.so RcppExports.o bindings.o -lv8 -lv8_libplatform -L/usr/lib64/R/lib -lR
installing to /tmp/RtmpxXcph0/Rinst1da5ce37509dae/00LOCK-V8/00new/V8/libs
** R
** inst
** byte-compile and prepare package for lazy loading
** help


#
# Fatal error in , line 0
# Check failed: isolate_ == isolate.
#
#
#
#FailureMessage Object: 0x7fff220659e0
==== C stack trace ===============================

    /usr/lib/libv8_libbase.so(v8::base::debug::StackTrace::StackTrace()+0x16) [0x7f2858779816]
    /usr/lib/libv8_libplatform.so(+0x149f8) [0x7f28587959f8]
    /usr/lib/libv8_libbase.so(V8_Fatal(char const*, ...)+0x19f) [0x7f285876716f]
    /usr/lib/libv8.so(v8::internal::WriteBarrier::GenerationalBarrierSlow(v8::internal::Tagged<v8::internal::HeapObject>, unsigned long, v8::internal::Tagged<v8::internal::HeapObject>)+0x185) [0x7f2856d28ac5]
    /usr/lib/libv8.so(v8::internal::ArrayList::Add(v8::internal::Isolate*, v8::internal::DirectHandle<v8::internal::ArrayList>, v8::internal::DirectHandle<v8::internal::Object>, v8::internal::AllocationType)+0x97) [0x7f2856fc7607]
    /usr/lib/libv8.so(v8::Isolate::AddMessageListenerWithErrorLevel(void (*)(v8::Local<v8::Message>, v8::Local<v8::Value>), int, v8::Local<v8::Value>)+0xf7) [0x7f2856a39e47]
    /tmp/RtmpxXcph0/Rinst1da5ce37509dae/00LOCK-V8/00new/V8/libs/V8.so(R_init_V8+0xf0) [0x7f285d483d30]
    /usr/lib64/R/lib/libR.so(+0x1d1c6) [0x7f28e321d1c6]
    /usr/lib64/R/lib/libR.so(+0x1e598) [0x7f28e321e598]
    /usr/lib64/R/lib/libR.so(+0x1162f3) [0x7f28e33162f3]
    /usr/lib64/R/lib/libR.so(+0x10e534) [0x7f28e330e534]
    /usr/lib64/R/lib/libR.so(Rf_eval+0x173) [0x7f28e32f9b33]
    /usr/lib64/R/lib/libR.so(+0xfef14) [0x7f28e32fef14]
    /usr/lib64/R/lib/libR.so(+0xfffef) [0x7f28e32fffef]
    /usr/lib64/R/lib/libR.so(Rf_eval+0x2c1) [0x7f28e32f9c81]
    /usr/lib64/R/lib/libR.so(+0xec74c) [0x7f28e32ec74c]
    /usr/lib64/R/lib/libR.so(+0xf24ff) [0x7f28e32f24ff]
    /usr/lib64/R/lib/libR.so(Rf_eval+0x60e) [0x7f28e32f9fce]
    /usr/lib64/R/lib/libR.so(Rf_eval+0x400) [0x7f28e32f9dc0]
    /usr/lib64/R/lib/libR.so(+0x105861) [0x7f28e3305861]
    /usr/lib64/R/lib/libR.so(+0x1162f3) [0x7f28e33162f3]
    /usr/lib64/R/lib/libR.so(+0x10e534) [0x7f28e330e534]
    /usr/lib64/R/lib/libR.so(Rf_eval+0x173) [0x7f28e32f9b33]
    /usr/lib64/R/lib/libR.so(+0xfc312) [0x7f28e32fc312]
    /usr/lib64/R/lib/libR.so(Rf_eval+0x3aa) [0x7f28e32f9d6a]
    /usr/lib64/R/lib/libR.so(+0x1061b2) [0x7f28e33061b2]
    /usr/lib64/R/lib/libR.so(+0x171c90) [0x7f28e3371c90]
    /usr/lib64/R/lib/libR.so(+0x115b7b) [0x7f28e3315b7b]
    /usr/lib64/R/lib/libR.so(+0x10e534) [0x7f28e330e534]
    /usr/lib64/R/lib/libR.so(Rf_eval+0x173) [0x7f28e32f9b33]
    /usr/lib64/R/lib/libR.so(+0xfef14) [0x7f28e32fef14]
    /usr/lib64/R/lib/libR.so(+0xfffef) [0x7f28e32fffef]
    /usr/lib64/R/lib/libR.so(R_forceAndCall+0x19e) [0x7f28e330121e]
    /usr/lib64/R/lib/libR.so(+0x322ba) [0x7f28e32322ba]
    /usr/lib64/R/lib/libR.so(+0x171c90) [0x7f28e3371c90]
    /usr/lib64/R/lib/libR.so(+0x115b7b) [0x7f28e3315b7b]
    /usr/lib64/R/lib/libR.so(+0x10e534) [0x7f28e330e534]
    /usr/lib64/R/lib/libR.so(Rf_eval+0x173) [0x7f28e32f9b33]
    /usr/lib64/R/lib/libR.so(+0xfef14) [0x7f28e32fef14]
    /usr/lib64/R/lib/libR.so(+0xfffef) [0x7f28e32fffef]
    /usr/lib64/R/lib/libR.so(Rf_eval+0x2c1) [0x7f28e32f9c81]
    /usr/lib64/R/lib/libR.so(+0x15ed40) [0x7f28e335ed40]
    /usr/lib64/R/lib/libR.so(run_Rmainloop+0x4a) [0x7f28e335f37a]
    /usr/lib64/R/bin/exec/R(main+0x21) [0x555c34208041]
    /usr/lib/libc.so.6(+0x276b5) [0x7f28e30376b5]
    /usr/lib/libc.so.6(__libc_start_main+0x89) [0x7f28e3037769]
    /usr/lib64/R/bin/exec/R(_start+0x25) [0x555c34208075]
/usr/lib64/R/bin/INSTALL: line 34: 1943008 Done                       echo 'tools:::.install_packages()'
     1943009 Trace/breakpoint trap      (core dumped) | R_DEFAULT_PACKAGES= LC_COLLATE=C "${R_HOME}/bin/R" $myArgs --no-echo --args ${args}
      -----------------------------------
ERROR: package installation failed
```